### PR TITLE
[BUGFIX] Store forced state in a cookie

### DIFF
--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -1,4 +1,8 @@
 <?php
+use TYPO3\CMS\Backend\Utility\IconUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /***************************************************************
 * Copyright notice
 *
@@ -37,19 +41,19 @@ class ext_update {
 	 * @var integer
 	 */
 	protected $majorVersion;
-	
+
 	/**
 	 * Holds the current localconf
 	 * @var array
 	 */
 	protected $extConf;
-	
+
 	/**
 	 * Holds the current ext_conf_template
 	 * @var array
 	 */
 	protected $extConfTemplateArr;
-	
+
 	/**
 	 * The constructor
 	 * @return ext_update
@@ -62,7 +66,7 @@ class ext_update {
 		$this->extConf		= $this->getExtConf();
 		$this->extConfTemplateArr   = $this->getExtConfTemplateArr();
 	}
-	
+
 	/**
 	 * Main function, returning the HTML content of the module
 	 *
@@ -71,20 +75,20 @@ class ext_update {
 	public function main() {
 		if(!$this->checkConfigs()) {
 			$out = 'Either your local configuration or the ext_conf_template.txt of this extension is empty or broken!';
-
 			return $out;
 		}
 
 		$differences = $this->getExtConfDifferences();
+		$out = '';
 
 		if(count($differences) > 0) {
-			if (t3lib_div::_GP('do_update')) {
-				if($this->updateExtConf(t3lib_div::_GP('func'))) {
+			if (GeneralUtility::_GP('do_update')) {
+				if($this->updateExtConf(GeneralUtility::_GP('func'))) {
 					$out .= 'Your local configuration has been updated. Thanks for chosing cwmobileredirect!<br>';
-					$out .= '<button onclick="location.href=\'' 
-							. t3lib_div::linkThisScript(array('do_update' => '', 'func' => '')) 
-							. '\'" value="" name="do_update" type="submit"><img style="vertical-align:bottom;" ' 
-							. t3lib_iconWorks::skinImg($GLOBALS['BACK_PATH'], 'gfx/refresh_n.gif', 'width="18" height="16"') 
+					$out .= '<button onclick="location.href=\''
+							. GeneralUtility::linkThisScript(array('do_update' => '', 'func' => ''))
+							. '\'" value="" name="do_update" type="submit"><img style="vertical-align:bottom;" '
+							. IconUtility::skinImg($GLOBALS['BACK_PATH'], 'gfx/refresh_n.gif', 'width="18" height="16"')
 							. '>Check for more updates</button><br><br><br>';
 				} else {
 					$out .= 'Your local configuration has been NOT updated. This most likely means that your cwmobileredirect installation is screwed. You should consider removing and installing it from scratch.';
@@ -94,39 +98,39 @@ class ext_update {
 
 				if(isset($differences['redirect_exceptions'])) {
 					$out .= $differences['redirect_exceptions'];
-					$out .= '<button onclick="location.href=\'' 
-							. t3lib_div::linkThisScript(array('do_update' => 'update', 'func' => 'redirect_exceptions')) 
-							. '\'" value="update" name="do_update" type="submit"><img style="vertical-align:bottom;" ' 
-							. t3lib_iconWorks::skinImg($GLOBALS['BACK_PATH'], 'gfx/refresh_n.gif', 'width="18" height="16"') 
+					$out .= '<button onclick="location.href=\''
+							. GeneralUtility::linkThisScript(array('do_update' => 'update', 'func' => 'redirect_exceptions'))
+							. '\'" value="update" name="do_update" type="submit"><img style="vertical-align:bottom;" '
+							. IconUtility::skinImg($GLOBALS['BACK_PATH'], 'gfx/refresh_n.gif', 'width="18" height="16"')
 							. '>Update redirect_exceptions</button><br><br><br>';
 				}
-				
+
 				if(isset($differences['regexp1'])) {
 					$out .= $differences['regexp1'];
 					$out .= 'This will OVERWRITE your existing mobile browser detection settings (First RegExp) in your local '
 							 . 'configuration with the current extension default settings.<br><br>';
-					$out .= '<button onclick="location.href=\'' 
-							. t3lib_div::linkThisScript(array('do_update' => 'update', 'func' => 'regexp1')) 
-							. '\'" value="update" name="do_update" type="submit"><img style="vertical-align:bottom;" ' 
-							. t3lib_iconWorks::skinImg($GLOBALS['BACK_PATH'], 'gfx/refresh_n.gif', 'width="18" height="16"') 
+					$out .= '<button onclick="location.href=\''
+							. GeneralUtility::linkThisScript(array('do_update' => 'update', 'func' => 'regexp1'))
+							. '\'" value="update" name="do_update" type="submit"><img style="vertical-align:bottom;" '
+							. IconUtility::skinImg($GLOBALS['BACK_PATH'], 'gfx/refresh_n.gif', 'width="18" height="16"')
 							. '>Update regexp1</button><br><br><br>';
 				}
-				
+
 				if(isset($differences['regexp2'])) {
 					$out .= $differences['regexp2'];
 					$out .= 'This will OVERWRITE your existing mobile browser detection settings (Second RegExp) in your local '
 							 . 'configuration with the current extension default settings.<br><br>';
-					$out .= '<button onclick="location.href=\'' 
-							. t3lib_div::linkThisScript(array('do_update' => 'update', 'func' => 'regexp2')) 
-							. '\'" value="update" name="do_update" type="submit"><img style="vertical-align:bottom;" ' 
-							. t3lib_iconWorks::skinImg($GLOBALS['BACK_PATH'], 'gfx/refresh_n.gif', 'width="18" height="16"') 
+					$out .= '<button onclick="location.href=\''
+							. GeneralUtility::linkThisScript(array('do_update' => 'update', 'func' => 'regexp2'))
+							. '\'" value="update" name="do_update" type="submit"><img style="vertical-align:bottom;" '
+							. IconUtility::skinImg($GLOBALS['BACK_PATH'], 'gfx/refresh_n.gif', 'width="18" height="16"')
 							. '>Update regexp1</button><br><br><br>';
 				}
 			}
 		} else {
 			$out .= 'Your localconf does not need to be updated!';
 		}
-		
+
 		return $out;
 	}
 
@@ -137,14 +141,16 @@ class ext_update {
 	 * @param  string  $what: what should be updated
 	 * @return boolean
 	 */
-	public function access($what = 'all')
-	{
+	public function access(
+		/** @noinspection PhpUnusedParameterInspection */
+		$what = 'all'
+	) {
 		return true;
 	}
-	
+
 	/**
-	 * Checks whether all configs are ok 
-	 * 
+	 * Checks whether all configs are ok
+	 *
 	 * @return boolean
 	 */
 	protected function checkConfigs()
@@ -159,7 +165,7 @@ class ext_update {
 
 		return true;
 	}
-	
+
 	/**
 	 * Returns the content of ext_conf_template.txt as handy array
 	 * @return boolean|array
@@ -167,27 +173,30 @@ class ext_update {
 	protected function getExtConfTemplateArr()
 	{
 		$extConfTemplateArr = array();
-		
+
 		// Fetch the current reg exps from the ext_conf_template.txt
 		if ($this->majorVersion >= 6) {
 			// Typo3 >= 6.0
-			$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
+			$objectManager = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
 			$configurationUtility = $objectManager->get('TYPO3\\CMS\\Extensionmanager\\Utility\\ConfigurationUtility');
-		
+
 			$extConfTemplateArr = $configurationUtility->getDefaultConfigurationFromExtConfTemplateAsValuedArray($this->extKey);
 		} else {
 			// Typo3 <= 4.7
+			/** @noinspection PhpUndefinedClassInspection */
 			$absPath = tx_em_Tools::getExtPath($this->extKey, 'L');
+			/** @noinspection PhpUndefinedClassInspection */
 			$relPath = tx_em_Tools::typeRelPath('L') . $this->extKey . '/';
 
-			if (t3lib_extMgm::isLoaded($this->extKey) 
+			/** @noinspection PhpUndefinedMethodInspection */
+			if (ExtensionManagementUtility::isLoaded($this->extKey)
 				&& (@is_file($absPath . 'ext_conf_template.txt') || $this->extensionHasCacheConfiguration($absPath))
 			) {
 					// Load tsStyleConfig class and parse configuration template:
-				$tsStyleConfig = t3lib_div::makeInstance('t3lib_tsStyleConfig');
+				$tsStyleConfig = GeneralUtility::makeInstance('t3lib_tsStyleConfig');
 				$tsStyleConfig->doNotSortCategoriesBeforeMakingForm = TRUE;
 				$extConfTemplateArr = $tsStyleConfig->ext_initTSstyleConfig(
-					t3lib_div::getUrl($absPath . 'ext_conf_template.txt'),
+					GeneralUtility::getUrl($absPath . 'ext_conf_template.txt'),
 					$relPath,
 					$absPath,
 					$GLOBALS['BACK_PATH']
@@ -197,9 +206,9 @@ class ext_update {
 
 		return $extConfTemplateArr;
 	}
-	
+
 	/**
-	 * Checks whether certain localconf whether 
+	 * Checks whether certain localconf whether
 	 * @return string|boolean
 	 */
 	protected function getExtConfDifferences()
@@ -215,7 +224,7 @@ class ext_update {
 			$retArray['regexp2'] = '<p><strong>regexp2 field differs from default!</strong><br><strong>local:</strong> ' . $this->extConf['regexp2']
 					. '<br><strong>default:</strong> ' . $this->extConfTemplateArr['regexp2']['value'] . '</p>';
 		}
-		
+
 		if(empty($this->extConf['redirect_exceptions'])) {
 			$retArray['redirect_exceptions'] = '<p><strong>redirect_exceptions field is empty!</strong>'
 					. '<br><strong>default:</strong> ' . $this->extConfTemplateArr['redirect_exceptions']['value'] . '</p>';
@@ -223,48 +232,57 @@ class ext_update {
 
 		return $retArray;
 	}
-	
+
 	/**
 	 * Upate the extConf
-	 * 
+	 *
 	 * @return boolean
 	 */
-	protected function updateExtConf($func) 
-	{
+	protected function updateExtConf(
+		/** @noinspection PhpDocSignatureInspection */
+		$func
+	) {
 		// Get the value from the ext_conf_template and store it in the local conf
 		$this->extConf[$func] = $this->extConfTemplateArr[$func]['value'];
 
 		// Rewrite local configuration according to Typo3 version
 		if ($this->majorVersion >= 6) {
 			// Typo3 >= 6.0
-			$configurationManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+			$configurationManager = GeneralUtility::makeInstance(
 				'TYPO3\\CMS\\Core\\Configuration\\ConfigurationManager'
 				);
 
 			$configurationManager->setLocalConfigurationValueByPath('EXT/extConf/' . $this->extKey, serialize($this->extConf));
 
-			\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::removeCacheFiles();
+			ExtensionManagementUtility::removeCacheFiles();
 		} else {
 			// Typo3 <= 4.7
+			/** @noinspection PhpUndefinedClassInspection */
 			$install = new t3lib_install();
+			/** @noinspection PhpUndefinedFieldInspection */
 			$install->allowUpdateLocalConf = 1;
+			/** @noinspection PhpUndefinedFieldInspection */
 			$install->updateIdentity = 'cwmobileredirect Updater';
 
+			/** @noinspection PhpUndefinedMethodInspection */
 			$lines = $install->writeToLocalconf_control();
+			/** @noinspection PhpUndefinedMethodInspection */
 			$install->setValueInLocalconfFile(
-				$lines, 
-				'$TYPO3_CONF_VARS[\'EXT\'][\'extConf\'][\'' . $this->extKey . '\']', 
+				$lines,
+				'$TYPO3_CONF_VARS[\'EXT\'][\'extConf\'][\'' . $this->extKey . '\']',
 				serialize($this->extConf)
 				);
 
+			/** @noinspection PhpUndefinedMethodInspection */
 			$install->writeToLocalconf_control($lines);
 
+			/** @noinspection PhpUndefinedClassInspection */
 			t3lib_extMgm::removeCacheFiles();
-		}   
+		}
 
 		return true;
 	}
-	
+
 	/**
 	 * Get the extension configuration
 	 *
@@ -280,9 +298,3 @@ class ext_update {
 		return $extConf;
 	}
 }
-
-if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/cwmobileredirect/class.ext_update.php']) {
-	include_once ($TYPO3_CONF_VARS[TYPO3_MODE]['XCLASS']['ext/cwmobileredirect/class.ext_update.php']);
-}
-
-?>

--- a/class.tx_cwmobileredirect.php
+++ b/class.tx_cwmobileredirect.php
@@ -386,6 +386,18 @@ class tx_cwmobileredirect
      */
     public function checkRedirect()
     {
+		// if the mobile version was forced we set / update the cookie
+		// and do not care about redirects
+		if($this->isMobileForced()) {
+			$this->setExtensionCookie(self::MOBILEREDIRECT_COOKIE_MOBILE);
+		}
+
+		// if the standard version was forced we set / update the cookie
+		// and do not care about redirects
+		if($this->isStandardForced()) {
+			$this->setExtensionCookie(self::MOBILEREDIRECT_COOKIE_STANDARD);
+		}
+
         // Don't do anything in this case
         if(!$this->isMobileUrlRequested() &&
             !$this->isStandardUrlRequested()

--- a/class.tx_cwmobileredirect.php
+++ b/class.tx_cwmobileredirect.php
@@ -22,6 +22,8 @@
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\HttpUtility;
 
 /**
  * Simple user_func that uses tx_mobileredirect to determine if the
@@ -412,7 +414,7 @@ class tx_cwmobileredirect
         // don't redirect in case of configured exceptions
 		// e.g. (rest\/news|events)|typo3conf
         if (!empty($this->_conf['redirect_exceptions']) &&
-			preg_match('/'.$this->_conf['redirect_exceptions'].'/', t3lib_div::getIndpEnv('REQUEST_URI')))
+			preg_match('/'.$this->_conf['redirect_exceptions'].'/', GeneralUtility::getIndpEnv('REQUEST_URI')))
         {
             return;
         }
@@ -551,7 +553,7 @@ class tx_cwmobileredirect
 
         $this->writeDebugLogArray();
 
-        t3lib_utility_Http::redirect($this->protocol . $url . $urlParam, $this->_conf['httpStatus']);
+        HttpUtility::redirect($this->protocol . $url . $urlParam, $this->_conf['httpStatus']);
     }
 
 
@@ -565,7 +567,7 @@ class tx_cwmobileredirect
     {
         // set default HTTP Status code, if not defined
         if ('' == $this->_conf['httpStatus'] || !defined('t3lib_utility_Http::'. $this->_conf['httpStatus'])) {
-            $this->_conf['httpStatus'] = t3lib_utility_Http::HTTP_STATUS_303;
+            $this->_conf['httpStatus'] = HttpUtility::HTTP_STATUS_303;
         } else {
             $this->_conf['httpStatus'] = constant('t3lib_utility_Http::'. $this->_conf['httpStatus']);
         }
@@ -712,7 +714,7 @@ class tx_cwmobileredirect
         // Thanks a lot!
 
         if(!$useragent) {
-            $useragent = t3lib_div::getIndpEnv('HTTP_USER_AGENT');
+            $useragent = GeneralUtility::getIndpEnv('HTTP_USER_AGENT');
         }
 
         // Run detection - if true, store status
@@ -748,7 +750,7 @@ class tx_cwmobileredirect
     protected function detectMobileBrowser($useragent = NULL)
     {
         if(!$useragent) {
-            $useragent = t3lib_div::getIndpEnv('HTTP_USER_AGENT');
+            $useragent = GeneralUtility::getIndpEnv('HTTP_USER_AGENT');
         }
 
         // go through the array of known mobile browsers and check

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+	"name": "intera-typo3-extension/cwmobileredirect",
+	"description": "Your all-in-one mobile device detection and redirection solution! Detects mobile browsers and redirects to other Typo3 sites in your setup (most likely optimized for mobiles). Allows to easily switch back to the normal version, with Cookie support to remember the users choice. The browser detection can be access via TypoScript or in your own extension.",
+	"type": "typo3-cms-extension",
+	"version": "1.4.3"
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,6 +2,6 @@
 
 if (!defined ("TYPO3_MODE"))     die ("Access denied.");
 
-$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/index_ts.php']['preprocessRequest'][] = t3lib_extMgm::extPath($_EXTKEY) . 'class.tx_cwmobileredirect.php:&tx_cwmobileredirect->firstEntryPoint';
+$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/index_ts.php']['preprocessRequest'][] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'class.tx_cwmobileredirect.php:&tx_cwmobileredirect->firstEntryPoint';
 
-$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['configArrayPostProc']['tx_cwmobileredirect'] = t3lib_extMgm::extPath($_EXTKEY) . 'class.tx_cwmobileredirect.php:&tx_cwmobileredirect->secondEntryPoint';
+$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['configArrayPostProc']['tx_cwmobileredirect'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'class.tx_cwmobileredirect.php:&tx_cwmobileredirect->secondEntryPoint';


### PR DESCRIPTION
When a link for forcing the mobile or the standard version is
used a cookie is set to store this selection for furture
requests.

Resolves: #49659
